### PR TITLE
fix(frontend): improve templates and tests

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+- Fixed duplicate script tags in several templates.
+- Corrected missing product image reference.
+- Added frontend integration tests using BeautifulSoup.
+- Ensured root URL routes to pages app.
+- Added BeautifulSoup dependency.

--- a/pages/tests/test_frontend.py
+++ b/pages/tests/test_frontend.py
@@ -1,0 +1,56 @@
+import os
+from bs4 import BeautifulSoup
+import pytest
+from django.urls import reverse, resolve
+from django.conf import settings
+import sitecore.urls
+from pages.views import StaticTemplateView
+
+# Collect URL patterns from pages/urls.py
+URLS = [
+    ("home", "pages/index.html"),
+    ("about", "pages/about.html"),
+    ("contact", "pages/contact.html"),
+    ("service", "pages/service.html"),
+    ("team", "pages/team.html"),
+    ("team-dark", "pages/team-dark.html"),
+    ("blog", "pages/blog-three-column.html"),
+    ("blog-post", "pages/blog-details-left-sidebar.html"),
+] + [(f"product-{i}", f"pages/product{i}.html") for i in range(1, 7)]
+
+
+@pytest.mark.parametrize("name, template", URLS)
+def test_url_resolution(name, template):
+    match = resolve(reverse(name))
+    assert match.func.view_class is StaticTemplateView
+    assert match.func.view_initkwargs["template_name"] == template
+
+
+@pytest.mark.parametrize("name, _template", URLS)
+def test_html_structure(client, name, _template):
+    response = client.get(reverse(name))
+    assert response.status_code == 200
+    soup = BeautifulSoup(response.content, "html.parser")
+    assert soup.html and soup.head and soup.body
+    assert soup.title is not None
+
+    # verify static asset references exist
+    for tag in soup.find_all(src=True):
+        src = tag["src"]
+        if src.startswith(settings.STATIC_URL):
+            rel_path = src[len(settings.STATIC_URL):]
+            found = any(
+                os.path.exists(os.path.join(static_dir, rel_path))
+                for static_dir in settings.STATICFILES_DIRS
+            )
+            assert found, f"Missing static asset: {src}"
+
+
+def test_root_url_configuration():
+    import pages.urls
+
+    assert any(
+        getattr(p.pattern, "_route", None) == ""
+        and getattr(p, "urlconf_name", None) is pages.urls
+        for p in sitecore.urls.urlpatterns
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,3 +33,4 @@ sqlparse==0.5.3
 typing_extensions==4.13.2
 virtualenv==20.31.2
 whitenoise==6.9.0
+beautifulsoup4==4.12.3

--- a/sitecore/settings/base.py
+++ b/sitecore/settings/base.py
@@ -56,9 +56,7 @@ ASGI_APPLICATION = "sitecore.asgi.application"
 DATABASES = {"default": env.db(default=f'sqlite:///{BASE_DIR / "db.sqlite3"}')}
 
 AUTH_PASSWORD_VALIDATORS = [
-    {
-        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"  # noqa: E501
-    },
+    {"NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"},  # noqa: E501
     {"NAME": "django.contrib.auth.password_validation.MinimumLengthValidator"},  # noqa: E501
     {"NAME": "django.contrib.auth.password_validation.CommonPasswordValidator"},  # noqa: E501
     {"NAME": "django.contrib.auth.password_validation.NumericPasswordValidator"},  # noqa: E501

--- a/sitecore/settings/dev.py
+++ b/sitecore/settings/dev.py
@@ -2,7 +2,7 @@ from .base import *  # noqa: F401,F403,F405
 
 DEBUG = True
 
-INSTALLED_APPS = INSTALLED_APPS + ['debug_toolbar']  # noqa: F405
+INSTALLED_APPS = INSTALLED_APPS + ["debug_toolbar"]  # noqa: F405
 MIDDLEWARE = [
     "debug_toolbar.middleware.DebugToolbarMiddleware",
 ] + MIDDLEWARE  # noqa: F405

--- a/sitecore/settings/prod.py
+++ b/sitecore/settings/prod.py
@@ -1,12 +1,12 @@
 from .base import *  # noqa: F401,F403,F405
 
-env.read_env(BASE_DIR / '.env.prod')  # noqa: F405
+env.read_env(BASE_DIR / ".env.prod")  # noqa: F405
 
 DEBUG = False
 
 MIDDLEWARE = (  # noqa: F405
     MIDDLEWARE[:1]  # noqa: F405
-    + ['whitenoise.middleware.WhiteNoiseMiddleware']
+    + ["whitenoise.middleware.WhiteNoiseMiddleware"]
     + MIDDLEWARE[1:]  # noqa: F405  # noqa: F405
 )  # noqa: F405
 
@@ -17,4 +17,4 @@ SECURE_HSTS_SECONDS = 31536000
 SECURE_HSTS_PRELOAD = True
 SECURE_HSTS_INCLUDE_SUBDOMAINS = True
 
-STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
+STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"

--- a/sitecore/urls.py
+++ b/sitecore/urls.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
 from django.urls import include, path
 from django.conf import settings
+
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("", include("pages.urls")),

--- a/templates/pages/404-dark.html
+++ b/templates/pages/404-dark.html
@@ -28,19 +28,4 @@
 
     </div>
 
-    <!-- JS
-============================================ -->
-
-    <!-- jQuery JS -->
-    <script src="{% static 'js/vendor/jquery-1.12.4.min.js' %}"></script>
-    <!-- Popper JS -->
-    <script src="{% static 'js/popper.min.js' %}"></script>
-    <!-- Bootstrap JS -->
-    <script src="{% static 'js/bootstrap.min.js' %}"></script>
-    <!-- Plugins JS -->
-    <script src="{% static 'js/plugins.js' %}"></script>
-    <!-- Ajax Mail -->
-    <script src="{% static 'js/ajax-mail.js' %}"></script>
-    <!-- Main JS -->
-    <script src="{% static 'js/main.js' %}"></script>
 {% endblock %}

--- a/templates/pages/404.html
+++ b/templates/pages/404.html
@@ -28,19 +28,4 @@
 
     </div>
 
-    <!-- JS
-============================================ -->
-
-    <!-- jQuery JS -->
-    <script src="{% static 'js/vendor/jquery-1.12.4.min.js' %}"></script>
-    <!-- Popper JS -->
-    <script src="{% static 'js/popper.min.js' %}"></script>
-    <!-- Bootstrap JS -->
-    <script src="{% static 'js/bootstrap.min.js' %}"></script>
-    <!-- Plugins JS -->
-    <script src="{% static 'js/plugins.js' %}"></script>
-    <!-- Ajax Mail -->
-    <script src="{% static 'js/ajax-mail.js' %}"></script>
-    <!-- Main JS -->
-    <script src="{% static 'js/main.js' %}"></script>
 {% endblock %}

--- a/templates/pages/blog-details-left-sidebar.html
+++ b/templates/pages/blog-details-left-sidebar.html
@@ -228,19 +228,4 @@
 
     </div>
 
-    <!-- JS
-============================================ -->
-
-    <!-- jQuery JS -->
-    <script src="{% static 'js/vendor/jquery-1.12.4.min.js' %}"></script>
-    <!-- Popper JS -->
-    <script src="{% static 'js/popper.min.js' %}"></script>
-    <!-- Bootstrap JS -->
-    <script src="{% static 'js/bootstrap.min.js' %}"></script>
-    <!-- Plugins JS -->
-    <script src="{% static 'js/plugins.js' %}"></script>
-    <!-- Ajax Mail -->
-    <script src="{% static 'js/ajax-mail.js' %}"></script>
-    <!-- Main JS -->
-    <script src="{% static 'js/main.js' %}"></script>
 {% endblock %}

--- a/templates/pages/blog-three-column.html
+++ b/templates/pages/blog-three-column.html
@@ -203,11 +203,4 @@
     <!-- Popper JS -->
     <script src="{% static 'js/popper.min.js' %}"></script>
     <!-- Bootstrap JS -->
-    <script src="{% static 'js/bootstrap.min.js' %}"></script>
-    <!-- Plugins JS -->
-    <script src="{% static 'js/plugins.js' %}"></script>
-    <!-- Ajax Mail -->
-    <script src="{% static 'js/ajax-mail.js' %}"></script>
-    <!-- Main JS -->
-    <script src="{% static 'js/main.js' %}"></script>
 {% endblock %}

--- a/templates/pages/product2.html
+++ b/templates/pages/product2.html
@@ -11,10 +11,7 @@
               <div
                 class="portfolio-details-image col-lg-7 col-12 mb-sm-30 mb-xs-30"
               >
-                <img
-                  src="{% static 'images/products/product2.png' %}"
-                  alt="UAV in action"
-                />
+                <img src="{% static 'images/products/2.png' %}" alt="UAV in action" />
                 <img
                   src="{% static 'images/products/2.png' %}"
                   alt="Precision drone surveying"


### PR DESCRIPTION
## Summary
- remove duplicate scripts from templates and fix broken image path
- add BeautifulSoup to requirements
- create frontend integration tests
- update URL tests for root routing
- document changes in changelog

## Testing
- `bandit -r pages sitecore`
- `mypy --ignore-missing-imports pages sitecore`
- `flake8`
- `pytest -q`
- `pytest --cov=pages --cov-report=term-missing -q`

------
https://chatgpt.com/codex/tasks/task_e_685acfd420f0832399d2940c773483cf